### PR TITLE
double clicking on a filtered tree bounces to top root

### DIFF
--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -121,18 +121,17 @@ module.exports = KBWidget({
                                     .attr('text-anchor','end')
                             ;
 
-                            //if (d.$lgv == undefined) {
-                                d.$lgv = GeneDistribution.bind(jqElem('div'))(
-                                    {
-                                        scaleAxes   : true,
-                                        customRegions : {
-                                            chart : d.lgvID
-                                        },
-                                        parent : $tree,
-                                        binHeight : $tree.options.lgvHeight,
-                                    }
-                                );
-                            //}
+                            d.$lgv = GeneDistribution.bind(jqElem('div'))(
+                                {
+                                    scaleAxes   : true,
+                                    customRegions : {
+                                        chart : d.lgvID
+                                    },
+                                    parent : $tree,
+                                    binHeight : $tree.options.lgvHeight,
+                                    selectionCallback : $wtgd.options.geneSelection
+                                }
+                            );
 
                         }
                     },

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -238,26 +238,17 @@ module.exports = KBWidget({
                         var isRoot = true;
 
                         var parent;
-                        if (this.originalRoot == undefined) {
-                            this.originalRoot = this.options.dataset;
+                        if (this.originalRoot == undefined || this.lastClicked !== d) {
+                            if (this.originalRoot == undefined) {
+                                this.originalRoot = this.options.dataset;
+                            }
+                            this.lastClicked = d;
                         }
                         else {
                             d = this.originalRoot;
                             this.originalRoot = undefined;
+                            this.lastClicked = undefined;
                         }
-
-                        /*if (! d.parent && this.filterParent.length) {
-                            d = this.filterParent.pop();
-                            delete d.stroke;
-                            isRoot = false;
-                        }
-                        else {
-                            var parent = d.parent;
-                            while (parent != undefined && parent.parent != undefined) {
-                                this.filterParent.unshift(parent);
-                                parent = parent.parent;
-                            }
-                        }*/
 
                         if (this.nodeState(d) == 'open') {
                             relayout(d);

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -238,11 +238,15 @@ module.exports = KBWidget({
                         var isRoot = true;
 
                         var parent;
-                        if (this.filterParent == undefined) {
-                            this.filterParent = [];
+                        if (this.originalRoot == undefined) {
+                            this.originalRoot = this.options.dataset;
+                        }
+                        else {
+                            d = this.originalRoot;
+                            this.originalRoot = undefined;
                         }
 
-                        if (! d.parent && this.filterParent.length) {
+                        /*if (! d.parent && this.filterParent.length) {
                             d = this.filterParent.pop();
                             delete d.stroke;
                             isRoot = false;
@@ -253,22 +257,24 @@ module.exports = KBWidget({
                                 this.filterParent.unshift(parent);
                                 parent = parent.parent;
                             }
-                        }
+                        }*/
 
-                        if (d.children && d.children.length) {
+                        if (this.nodeState(d) == 'open') {
                             relayout(d);
-                            d.stroke = this.filterParent.length ? 'cyan' : 'darkslateblue';
+                            d.stroke = this.originalRoot ? 'cyan' : 'darkslateblue';
 
                             this.setDataset(d);
 
                             if ($wtgd.options.taxonDblClick != undefined) {
                                 $wtgd.options.taxonDblClick.call(this, d, isRoot);
                             }
+
+                            if ($wtgd.options.treeRootChange) {
+                                $wtgd.options.treeRootChange.call(this, d);
+                            }
+
                         }
 
-                        if ($wtgd.options.treeRootChange) {
-                            $wtgd.options.treeRootChange.call(this, d);
-                        }
 
                     },
 

--- a/kb/kbaseVisWidget.js
+++ b/kb/kbaseVisWidget.js
@@ -41,6 +41,10 @@ KBWidget({
 
     width: '100%',
     height: '100%',
+
+    tooltipLeftOffset : 10,
+    tooltipTopOffset : 10,
+
   },
 
   shouldScaleAxis: function (axis) {
@@ -827,8 +831,8 @@ KBWidget({
     d3.selectAll('.visToolTip')
       .style('display', 'block')
       .html(args.label)
-      .style("left", (args.event.pageX + 10) + "px")
-      .style("top", (args.event.pageY - 10) + "px");
+      .style("left", (args.event.pageX + (args.tooltipLeftOffset || this.options.tooltipLeftOffset)) + "px")
+      .style("top", (args.event.pageY - (args.tooltipTopOffset || this.options.tooltipTopOffset)) + "px");
   },
 
   hideToolTip: function (args) {

--- a/vis.js
+++ b/vis.js
@@ -38,6 +38,9 @@ var Vis = React.createClass({
         treeRootChange : function(d) {
             console.log('changed root to ', d);
         },
+        geneSelection : function(bins) {
+            console.log("I SELECTED THESE BINS : ", bins)
+        },
       }
     )
   },


### PR DESCRIPTION
several new features:
- double clicking on a filtered subtree root will now jump to the absolute root, not one level up. Double clicking on a further subtree further filters.
- Drag across bins to select them and hand bins through to an arbitrary callback. Drag up or down perpendicular to bins to cancel selection.
