### PR TITLE
Modernization of selection

### DIFF
--- a/kb/GeneDistribution.js
+++ b/kb/GeneDistribution.js
@@ -4,11 +4,11 @@ var d3 = require('d3');
 
 module.exports = KBWidget({
 
-  name: "GeneDistribution",
-  parent: "kbaseVisWidget",
+    name: "GeneDistribution",
+    parent: "kbaseVisWidget",
 
-  version: "1.0.0",
-  options: {
+    version: "1.0.0",
+    options: {
     xScaleType: 'ordinal',
     overColor: 'yellow',
     strokeWidth: '2',
@@ -20,7 +20,7 @@ module.exports = KBWidget({
     debug: false,
     regionSaturation : 0.25,
     unachoredBinColor : 'lightgray',
-    dragColor : 'cyan',
+    dragColor : 'red',
     highlightColor : 'red',
 
     tooltipLeftOffset : 10,
@@ -28,23 +28,23 @@ module.exports = KBWidget({
 
     colorScale: function (idx) {
 
-      var c1 = d3.scale.category20();
-      var c2 = d3.scale.category20b();
-      var c3 = d3.scale.category20c();
+        var c1 = d3.scale.category20();
+        var c2 = d3.scale.category20b();
+        var c3 = d3.scale.category20c();
 
-      return function (idx) {
+        return function (idx) {
 
         if (idx < 20 || idx >= 60) {
-          var color = c1(idx % 20)
-          return color;
+            var color = c1(idx % 20)
+            return color;
         }
         else if (idx < 40) {
-          return c2(idx % 20)
+            return c2(idx % 20)
         }
         else if (idx < 60) {
-          return c3(idx % 20)
+            return c3(idx % 20)
         }
-      }
+        }
     },
 
     inset: 5,
@@ -52,137 +52,156 @@ module.exports = KBWidget({
 
     transitionTime: 200,
 
-  },
+    },
 
-  _accessors: [],
+    _accessors: [],
 
-  binColorScale: function (data, maxColor) {
+    binColorScale: function (data, maxColor) {
 
     var max = 0;
 
     data.forEach(
-      function (bin, idx) {
+        function (bin, idx) {
         if (bin.results) {
-          if (bin.results.count > max) {
+            if (bin.results.count > max) {
             max = bin.results.count;
-          }
+            }
         }
-      }
+        }
     )
 
     return d3.scale.linear()
-      .domain([0, max])
-      .range(['#FFFFFF', maxColor])
-  },
+        .domain([0, max])
+        .range(['#FFFFFF', maxColor])
+    },
 
-  renderXAxis: function () {},
-  renderYAxis: function () {},
+    renderXAxis: function () {},
+    renderYAxis: function () {},
 
-  domain: function (data) {
+    domain: function (data) {
 
     var start = 1000000;
     var end = -1000000;
 
     for (var i = 0; i < data.length; i++) {
 
-      if (data[i].end > end) {
+        if (data[i].end > end) {
         end = data[i].end
-      }
+        }
 
-      if (data[i].start < start) {
+        if (data[i].start < start) {
         start = data[i].start
-      }
+        }
 
     }
 
     return [start, end];
 
-  },
+    },
 
-  regionDomain: function (data) {
+    regionDomain: function (data) {
 
     var length = 0;
     var lastVal = {end: 0}
     data.forEach(
-      function (val, idx) {
+        function (val, idx) {
         length += val.size;
         val.start = lastVal.end;
         val.end = val.start + val.size;
         lastVal = val;
-      }
+        }
     )
 
     return [0, length];
-  },
+    },
 
-  setDataset: function (genome) {
+    setDataset: function (genome) {
     var regions = [];
     genome.eachRegion(function (region) {
-      regions.push(region);
+        regions.push(region);
     });
 
     this._super(regions);
-  },
+    },
 
-  showHighlightBox : function() {
+    showHighlightBox : function() {
     this.highlightBox.attr('visibility', 'visible');
 
     if (this.options.showHighlightCallback) {
         this.options.showHighlightCallback.call(this);
     }
 
-  },
+    },
 
-  hideHighlightBox : function() {
+    hideHighlightBox : function() {
     this.highlightBox.attr('visibility', 'hidden');
 
     if (this.options.hideHighlightCallback) {
         this.options.hideHighlightCallback.call(this);
     }
-  },
+    },
 
-  renderChart: function () {
+    binsInRange : function(bins, start, end) {
+        var results = [];
+
+        bins.forEach(
+            function (bin, idx) {
+                if (bin.start + bin.regionObj.start >= start && bin.end + bin.regionObj.start <= end) {
+                    results.push(bin);
+                }
+            }
+        )
+
+        return results;
+
+    },
+
+    renderChart: function () {
 
     if (this.dataset() == undefined) {
-      return;
+        return;
     }
     var bounds = this.chartBounds();
 
     var regionDomain = this.regionDomain(this.dataset());
 
     var scale = d3.scale.linear()
-      .domain(regionDomain)
-      .range([0, bounds.size.width]);
+        .domain(regionDomain)
+        .range([0, bounds.size.width]);
 
     var $gd = this;
 
     var mouseAction = function (d, i) {
-      this.on('mouseover', function (b, j) {
+        this.on('mouseover', function (b, j) {
+
+        if ($gd.dragging) {
+            return;
+        }
 
         if ($gd.options.tooltip) {
-          $gd.options.tooltip(b);
+            $gd.options.tooltip(b);
         }
         else if (b.start && b.regionObj.name) {
-          score = b.results ? b.results.count : 0;
-          if (score) {
+            score = b.results ? b.results.count : 0;
+            if (score) {
             var units = (score > 1) ? ' genes' : ' gene';
             $gd.showToolTip({label: b.regionObj.name + ':' + b.start + '-' + b.end + ' ' + score + units})
-          }
-          else {
+            }
+            else {
             $gd.showToolTip({label: b.regionObj.name + ':' + b.start + '-' + b.end})
-          }
+            }
         }
-      })
+        })
         .on('mouseout', function (b, j) {
-          $gd.hideToolTip()
-          $gd.hideHighlightBox();
+            $gd.hideToolTip()
+            $gd.hideHighlightBox();
         })
         .on('click', function (b, j) {
-          if ($gd.options.binClick) {
+            if ($gd.options.binClick) {
             $gd.options.binClick.call($gd, b, this);
-          }
+            }
         });
-      return this;
+        return this;
     };
 
     var bins = [];
@@ -190,23 +209,26 @@ module.exports = KBWidget({
     var maxBinScore = 0;
 
     this.dataset().forEach(
-      function (region, idx) {
+        function (region, idx) {
         region.eachBin(function (bin) {
-          bin.regionObj = region;
-          bins.push(bin);
-          var score = bin.results ? bin.results.count : 0;
-          genomeTotalScore += score;
+            /*if (! bin.results || bin.results.count == 0) {
+            return;
+            }*/
+            bin.regionObj = region;
+            bins.push(bin);
+            var score = bin.results ? bin.results.count : 0;
+            genomeTotalScore += score;
 
-          if (score > maxBinScore && region.name != 'UNANCHORED') {
+            if (score > maxBinScore && region.name != 'UNANCHORED') {
             maxBinScore = score;
-          }
+            }
         })
-      }
+        }
     );
 
     var transitionTime = this.initialized
-      ? this.options.transitionTime
-      : 0;
+        ? this.options.transitionTime
+        : 0;
 
     var regionsSelection = this.D3svg().select(this.region('chart')).selectAll('.regions').data([0]);
     regionsSelection.enter().append('g').attr('class', 'regions');
@@ -214,38 +236,47 @@ module.exports = KBWidget({
     var regionSelection = regionsSelection.selectAll('.region').data(this.dataset(), function (d) { return d.name});
 
     regionSelection
-      .enter()
-          .append('rect')
-          .attr('class', 'region')
-          .attr('opacity', 0)
-          //                        .attr('transform', function (d) {return "translate(" + scale(d.start) + ",0)"})
-          .attr('x', bounds.size.width)
-          .attr('y', 0)
-          .attr('width', 0)
-          .attr('height', $gd.options.binHeight || bounds.size.height)
+        .enter()
+            .append('rect')
+            .attr('class', 'region')
+            .attr('opacity', 0)
+            //            .attr('transform', function (d) {return "translate(" + scale(d.start) + ",0)"})
+            .attr('x', bounds.size.width)
+            .attr('y', 0)
+            .attr('width', 0)
+            .attr('height', $gd.options.binHeight || bounds.size.height)
+            /*.on('mouseenter', function(e) {
+            if (! $gd.dragging) {
+                $gd.showHighlightBox();
+            }
+            })
+            .on('mouseout', function(e) {
+            $gd.hideHighlightBox();
+            })*/
         ;
 
 
     regionSelection
-      //.call(function (d) { return mouseAction.call(this, d) })
-      .transition()
-      .duration(transitionTime)
-      .attr('opacity', 1)
-      .attr('x', function (d) {return scale(d.start) })
-      .attr('width', function (d) { return scale((d.size)) })
-      .attr('fill', function (d, i) {
+        //.call(function (d) { return mouseAction.call(this, d) })
+        .transition()
+        .duration(transitionTime)
+        .attr('opacity', 1)
+        .attr('x', function (d) {return scale(d.start) })
+        .attr('width', function (d) { return scale((d.size)) })
+        .attr('fill', function (d, i) {
         var colorScale = d3.scale.linear().domain([0, 1]).range(['#FFFFFF', $gd.colorForRegion(d.name)])
         return colorScale($gd.options.regionSaturation);
-      });
+        })
+    ;
 
     regionSelection
-      .exit()
-      .transition()
-      .duration(transitionTime)
-      .attr('opacity', 0)
-      .attr('x', bounds.size.width + 1)
-      .attr('width', 0)
-      .each('end', function (d) { d3.select(this).remove() });
+        .exit()
+        .transition()
+        .duration(transitionTime)
+        .attr('opacity', 0)
+        .attr('x', bounds.size.width + 1)
+        .attr('width', 0)
+        .each('end', function (d) { d3.select(this).remove() });
 
     var binsSelection = this.D3svg().select(this.region('chart')).selectAll('.bins').data([0]);
     binsSelection.enter().append('g').attr('class', 'bins');
@@ -254,7 +285,8 @@ module.exports = KBWidget({
         .on('dragstart', function(d) {
             $gd.dragging = true;
             $gd.validDrag = true;
-            $gd.hideHighlightBox();
+            //$gd.hideHighlightBox();
+            $gd.highlightBox.attr('visibility', 'hidden');
         })
         .on('drag', function(d) {
             var coordinates = [0, 0];
@@ -263,83 +295,125 @@ module.exports = KBWidget({
 
             if (coordinates[1] < 0 || coordinates[1] > bounds.height) {
                 $gd.dragBox.attr('visibility', 'hidden');
+                $gd.hideToolTip();
+                //$gd.hideHighlightBox();
                 $gd.validDrag = false;
             }
             else {
                 $gd.validDrag = true;
+                $gd.showHighlightBox();
+                //same hack. We need the callback to fire, but we don't actually want to show it.
+                $gd.highlightBox.attr('visibility', 'hidden');
             }
         })
         .on('dragend', function(d) {
             $gd.dragging = false;
+            dragRegion = undefined;
 
             var binX = parseFloat($gd.dragBox.attr('x'));
             var binEnd = parseFloat($gd.dragBox.attr('width')) + binX;
 
             if ($gd.validDrag) {
-                var callbackBins = [];
-                selectedBins.forEach(
-                    function(d, idx) {
 
-                        var dX = scale(d.start + d.regionObj.start);
+                var selectedBins = $gd.binsInRange(bins, dragRange[0], dragRange[1]);
 
-                        if (Math.floor(binX) <= dX && Math.floor(dX) < binEnd && callbackBins.indexOf(d) == -1) {
-                            callbackBins.push(d);
-                        }
+                if (selectedBins.length) {
 
-                    }
-                );
-
-                if (callbackBins.length) {
+                    $gd.showToolTip(
+                        {label : "<a>Display region</a> <a>Cancel</a>"}
+                    );
 
                     if ($gd.options.selectionCallback) {
-                        $gd.options.selectionCallback.call(this, callbackBins);
+                        $gd.options.selectionCallback.call(this, {start : selectedBins[0], end : selectedBins[selectedBins.length - 1]});
                     }
 
                 }
 
             }
 
-            $gd.dragBox.attr('visibility', 'hidden');
+//            $gd.dragBox.attr('visibility', 'hidden');
+            dragRange = [];
         })
 
     var binSelection = binsSelection.selectAll('.bin').data(bins);
 
     var initialBox = undefined;
-    var selectedBins = [];
+    var dragRange = [];
+    var dragRegion = undefined;
 
     binSelection
-      .enter()
-          .append('rect')
-          .attr('class', 'bin')
-          .attr('opacity', 0)
-          .attr('x', bounds.size.width)
-          .attr('y', 0)
-          .attr('width', 0)
-          .attr('height', $gd.options.binHeight || bounds.size.height)
-          .attr('style', 'cursor : pointer')
-          .on('mousedown', function (d) {
+        .enter()
+            .append('rect')
+            .attr('class', 'bin')
+            .attr('opacity', 0)
+            .attr('x', bounds.size.width)
+            .attr('y', 0)
+            .attr('width', 0)
+            .attr('height', $gd.options.binHeight || bounds.size.height)
+            .attr('style', 'cursor : pointer')
+            .on('mousedown', function (d) {
                 initialBox = this.getBBox();
+                dragRegion = d.regionObj;
                 $gd.dragBox.attr('x', initialBox.x)
                 $gd.dragBox.attr('width', initialBox.width);
                 $gd.dragBox.attr('visibility', 'visible');
 
-                selectedBins = [];
-                selectedBins.push(d);
-          })
-          .on('mouseenter', function(d) {
+                dragRange = [d.start + d.regionObj.start, d.end + d.regionObj.start];
+            })
+            .on('mouseenter', function(d) {
             if ($gd.dragging) {
 
                 var box = this.getBBox();
+
+                if (d.regionObj !== dragRegion) {
+
+                    var firstBin = undefined;
+                    var lastBin = undefined;
+                    var foundRegion = false;
+
+                    for (var i = 0; i < bins.length; i++) {
+                        var bin = bins[i];
+
+                        if (bin.regionObj === dragRegion && firstBin == undefined) {
+                            firstBin = bin;
+                            foundRegion = true;
+                            continue;
+                        }
+
+                        if (foundRegion && bin.regionObj !== dragRegion) {
+                            break;
+                        }
+
+                        lastBin = bin;
+
+                    }
+
+                    if (box.x <= initialBox.x) {
+                        d = firstBin;
+                    }
+                    else if (box.x > initialBox.x) {
+                        d = lastBin;
+                    }
+
+                    var pos = d.start + d.regionObj.start;
+                    var node = d3.select('[data-start="' + pos + '"]');
+
+                    if (node) {
+                        box = node[0][0].getBBox();
+                    }
+
+                }
 
                 var binX = parseFloat($gd.dragBox.attr('x'));
                 var binEnd = parseFloat($gd.dragBox.attr('width')) + binX;
 
                 if (box.x <= initialBox.x) {
                     binX = box.x
+                    dragRange[0] = d.start + d.regionObj.start;
                 }
-
-                if (box.x > initialBox.x) {
+                if (box.x >= initialBox.x) {
                     binEnd = box.x + box.width;
+                    dragRange[1] = d.end + d.regionObj.start;
                 }
 
                 $gd.dragBox.attr('x', binX);
@@ -349,25 +423,44 @@ module.exports = KBWidget({
                 $gd.dragBox.attr('width', binWidth);
                 $gd.dragBox.attr('visibility', 'visible');
 
-                selectedBins.push(d);
+                var selectedBins = $gd.binsInRange(bins, dragRange[0], dragRange[1]);
+                var score = 0;
+                selectedBins.forEach(
+                    function (bin, idx) {
+                        if (bin.results) {
+                            score += bin.results.count;
+                        }
+                    }
+                )
+
+                var units = (score > 1) ? ' genes' : ' gene';
+                $gd.showToolTip({label: d.regionObj.name + ':' + (dragRange[0] - d.regionObj.start) + '-' + (dragRange[1] - d.regionObj.start) + ' ' + score + units})
+
             }
             else {
+                //we need to do this to ensure that the callback fires, since we are re-highlighting
                 $gd.showHighlightBox();
+                //but we don't actually want to show the box if we're dragging, so we duck internally to this.
+                if (dragRegion != undefined) {
+                    $gd.highlightBox.attr('visibility', 'hidden');
+                }
             }
 
-           })
+             })
 
-          .call(function (d) { return mouseAction.call(this, d) })
-          .call(drag)
+            .call(function (d) { return mouseAction.call(this, d) })
+            .call(drag)
     ;
 
     binSelection
-      .transition()
-      .duration(transitionTime)
-      .attr('opacity', function (d) { return (d.results && d.results.count) || d.regionObj.name == 'UNANCHORED' ? 1 : 0})
-      .attr('x', function (d) { return scale(d.start + d.regionObj.start) })
-      .attr('width', function (d) { return scale((d.end - d.start)) })
-      .attr('fill', function (d, i) {
+        .transition()
+        .duration(transitionTime)
+        .attr('opacity', function (d) { return (d.results && d.results.count) || d.regionObj.name == 'UNANCHORED' ? 1 : 0})
+        .attr('x', function (d) { return Math.round(scale(d.start + d.regionObj.start)) })
+        .attr('width', function (d) { return Math.round(scale((d.end - d.start))) })
+        .attr('data-start', function (d) { return d.start + d.regionObj.start})
+        .attr('data-end', function (d) { return d.end + d.regionObj.start})
+        .attr('fill', function (d, i) {
 
         if (d.regionObj.name == 'UNANCHORED') {
             return $gd.options.unachoredBinColor;
@@ -376,21 +469,21 @@ module.exports = KBWidget({
         var colorScale = d3.scale.linear().domain([0, 1]).range(['#FFFFFF', $gd.colorForRegion(d.region)])
         var scale = d3.scale.linear().domain([0, 1]).range([colorScale(.5), $gd.colorForRegion(d.region)]);
         if (!d.results || d.results.count === 0) {
-          return colorScale(.25);
+            return colorScale(.25);
         }
         else {
-          return scale( d.results.count / maxBinScore );
+            return scale( d.results.count / maxBinScore );
         }
-       });
+         });
 
     binSelection
-      .exit()
-      .transition()
-      .duration(transitionTime)
-      .attr('opacity', 0)
-      .attr('x', bounds.size.width + 1)
-      .attr('width', 0)
-      .each('end', function (d) { d3.select(this).remove() });
+        .exit()
+        .transition()
+        .duration(transitionTime)
+        .attr('opacity', 0)
+        .attr('x', bounds.size.width + 1)
+        .attr('width', 0)
+        .each('end', function (d) { d3.select(this).remove() });
 
     $gd.dragBox = this.D3svg().select(this.region('chart')).selectAll('.dragBox').data([0]);
 
@@ -428,21 +521,22 @@ module.exports = KBWidget({
     this.initialized = true;
 
 
-  },
+    },
 
-  colorForRegion: function (region, colorScale) {
+    colorForRegion: function (region, colorScale) {
     var map = this.regionColors;
     if (map == undefined) {
-      map = this.regionColors = {colorScale: this.options.colorScale()};
+        map = this.regionColors = {colorScale: this.options.colorScale()};
     }
 
     if (map[region] == undefined) {
-      map[region] = map.colorScale(d3.keys(map).length);
+        map[region] = map.colorScale(d3.keys(map).length);
     }
 
     return map[region];
 
-  }
+    }
 
 
 });
+

--- a/kb/GeneDistribution.js
+++ b/kb/GeneDistribution.js
@@ -319,10 +319,6 @@ module.exports = KBWidget({
 
                 if (selectedBins.length) {
 
-                    $gd.showToolTip(
-                        {label : "<a>Display region</a> <a>Cancel</a>"}
-                    );
-
                     if ($gd.options.selectionCallback) {
                         $gd.options.selectionCallback.call(this, {start : selectedBins[0], end : selectedBins[selectedBins.length - 1]});
                     }

--- a/kb/GeneDistribution.js
+++ b/kb/GeneDistribution.js
@@ -380,7 +380,7 @@ module.exports = KBWidget({
                 .attr('x', 0)
                 .attr('y', 0)
                 .attr('fill', $gd.options.dragColor)
-                .attr('fill-opacity', 0.3)
+                .attr('fill-opacity', 0.6)
                 .attr('pointer-events', 'none')
     ;
 

--- a/kb/GeneDistribution.js
+++ b/kb/GeneDistribution.js
@@ -272,7 +272,7 @@ module.exports = KBWidget({
                 if (callbackBins.length) {
 
                     if ($gd.options.selectionCallback) {
-                        $gd.options.selectionCallback(callbackBins);
+                        $gd.options.selectionCallback.call(this, callbackBins);
                     }
 
                 }

--- a/kb/GeneDistribution.js
+++ b/kb/GeneDistribution.js
@@ -21,6 +21,7 @@ module.exports = KBWidget({
     regionSaturation : 0.25,
     unachoredBinColor : 'lightgray',
     dragColor : 'cyan',
+    highlightColor : 'red',
 
     tooltipLeftOffset : 10,
     tooltipTopOffset : -15,
@@ -123,6 +124,23 @@ module.exports = KBWidget({
     this._super(regions);
   },
 
+  showHighlightBox : function() {
+    this.highlightBox.attr('visibility', 'visible');
+
+    if (this.options.showHighlightCallback) {
+        this.options.showHighlightCallback.call(this);
+    }
+
+  },
+
+  hideHighlightBox : function() {
+    this.highlightBox.attr('visibility', 'hidden');
+
+    if (this.options.hideHighlightCallback) {
+        this.options.hideHighlightCallback.call(this);
+    }
+  },
+
   renderChart: function () {
 
     if (this.dataset() == undefined) {
@@ -157,6 +175,7 @@ module.exports = KBWidget({
       })
         .on('mouseout', function (b, j) {
           $gd.hideToolTip()
+          $gd.hideHighlightBox();
         })
         .on('click', function (b, j) {
           if ($gd.options.binClick) {
@@ -235,6 +254,7 @@ module.exports = KBWidget({
         .on('dragstart', function(d) {
             $gd.dragging = true;
             $gd.validDrag = true;
+            $gd.hideHighlightBox();
         })
         .on('drag', function(d) {
             var coordinates = [0, 0];
@@ -331,6 +351,10 @@ module.exports = KBWidget({
 
                 selectedBins.push(d);
             }
+            else {
+                $gd.showHighlightBox();
+            }
+
            })
 
           .call(function (d) { return mouseAction.call(this, d) })
@@ -381,6 +405,23 @@ module.exports = KBWidget({
                 .attr('y', 0)
                 .attr('fill', $gd.options.dragColor)
                 .attr('fill-opacity', 0.6)
+                .attr('pointer-events', 'none')
+    ;
+
+    $gd.highlightBox = this.D3svg().select(this.region('chart')).selectAll('.highlightBox').data([0]);
+
+    $gd.highlightBox
+        .enter()
+            .append('rect')
+                .attr('class', 'highlightBox')
+                .attr('visibility', 'hidden')
+                .attr('height', $gd.options.binHeight || bounds.size.height)
+                .attr('width', bounds.size.width)
+                .attr('x', 0)
+                .attr('y', 0)
+                .attr('stroke', $gd.options.highlightColor)
+                .attr('stroke-width', 2)
+                .attr('fill', 'none')
                 .attr('pointer-events', 'none')
     ;
 

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -130,7 +130,48 @@ module.exports = KBWidget({
                                     },
                                     parent : $tree,
                                     binHeight : $tree.options.lgvHeight,
-                                    selectionCallback : $wtgd.options.geneSelection
+                                    selectionCallback : $wtgd.options.geneSelection,
+
+                                    showHighlightCallback : function() {
+                                        d3.select(node).selectAll('.nodeText')
+                                            .attr('fill', this.options.highlightColor)
+                                            .attr('font-style', 'italic')
+                                        ;
+
+                                        var nodes = d.id.split('/');
+
+                                        while (nodes.length) {
+                                            var nodeID = nodes.join('/');
+
+                                            $tree.data('D3svg').select($tree.region('chart')).selectAll('[data-node-id="' + nodeID + '"]')
+                                                    .attr('stroke', this.options.highlightColor)
+
+                                            nodes.pop();
+                                        }
+
+                                    },
+
+                                    hideHighlightCallback : function() {
+                                        if (! this.dragging) {
+                                            d3.select(node).selectAll('.nodeText')
+                                                .attr('fill', 'black')
+                                                .attr('font-style', '')
+                                            ;
+
+                                            var nodes = d.id.split('/');
+
+                                            while (nodes.length) {
+                                                var nodeID = nodes.join('/');
+
+                                                $tree.data('D3svg').select($tree.region('chart')).selectAll('[data-node-id="' + nodeID + '"]')
+                                                        .attr('stroke', $tree.options.lineStroke)
+
+                                                nodes.pop();
+                                            }
+                                        }
+
+
+                                    },
                                 }
                             );
 

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -152,7 +152,7 @@ module.exports = KBWidget({
                                     },
 
                                     hideHighlightCallback : function() {
-                                        if (! this.dragging) {
+                                        //if (! this.dragging) {
                                             d3.select(node).selectAll('.nodeText')
                                                 .attr('fill', 'black')
                                                 .attr('font-style', '')
@@ -168,7 +168,7 @@ module.exports = KBWidget({
 
                                                 nodes.pop();
                                             }
-                                        }
+                                        //}
 
 
                                     },

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -80,6 +80,7 @@ module.exports = KBWidget({
                 {
 
                     nodeEnterCallback : function(d, i, node, duration) {
+
                         if (d.model.genome) {
                             var $tree = this;
 
@@ -168,6 +169,15 @@ module.exports = KBWidget({
                     fixed           : true,
                     labelWidth      : 100,
                     nodeHeight      : 7,
+
+                    depth : function(d, rootOffset, chartOffset) {
+                        if (d.parent == undefined) {
+                            return -5;
+                        }
+                        else {
+                            return this.defaultDepth(d, rootOffset, chartOffset);
+                        }
+                    },
 
                     strokeWidth : function(d) {
 

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -66,22 +66,15 @@ module.exports = KBWidget({
             }
         },
 
-        dehighlightTree : function(d, node, $lgv, $tree) {
+        dehighlightTree : function($tree) {
             d3.select(node).selectAll('.nodeText')
                 .attr('fill', 'black')
                 .attr('font-style', '')
             ;
 
-            var nodes = d.id.split('/');
+            $tree.data('D3svg').select($tree.region('chart')).selectAll('.link')
+                    .attr('stroke', $tree.options.lineStroke)
 
-            while (nodes.length) {
-                var nodeID = nodes.join('/');
-
-                $tree.data('D3svg').select($tree.region('chart')).selectAll('[data-node-id="' + nodeID + '"]')
-                        .attr('stroke', $tree.options.lineStroke)
-
-                nodes.pop();
-            }
         },
 
         init : function(options) {
@@ -187,7 +180,7 @@ module.exports = KBWidget({
                                     showHighlightCallback : function() {
 
                                         if ($wtgd.lastSelection) {
-                                            $wtgd.dehighlightTree($wtgd.lastSelection.d, $wtgd.lastSelection.node, $wtgd.lastSelection.$lgv, $tree);
+                                            $wtgd.dehighlightTree($tree);
                                         }
 
                                         $wtgd.highlightTree(d, node, this, $tree);
@@ -195,7 +188,7 @@ module.exports = KBWidget({
 
                                     hideHighlightCallback : function() {
 
-                                        $wtgd.dehighlightTree(d, node, this, $tree);
+                                        $wtgd.dehighlightTree($tree);
 
                                         if ($wtgd.lastSelection) {
                                             $wtgd.highlightTree($wtgd.lastSelection.d, $wtgd.lastSelection.node, $wtgd.lastSelection.$lgv, $tree);

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -169,6 +169,7 @@ module.exports = KBWidget({
                     fixed           : true,
                     labelWidth      : 100,
                     nodeHeight      : 7,
+                    staticWidth     : true,
 
                     depth : function(d, rootOffset, chartOffset) {
                         if (d.parent == undefined) {

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -258,6 +258,7 @@ module.exports = KBWidget({
                             d = this.originalRoot;
                             this.originalRoot = undefined;
                             this.lastClicked = undefined;
+                            isRoot = false;
                         }
 
                         if (this.nodeState(d) == 'open') {

--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -67,7 +67,7 @@ module.exports = KBWidget({
         },
 
         dehighlightTree : function($tree) {
-            d3.select(node).selectAll('.nodeText')
+            $tree.data('D3svg').select($tree.region('chart')).selectAll('.nodeText')
                 .attr('fill', 'black')
                 .attr('font-style', '')
             ;

--- a/kb/kbaseTreechart.js
+++ b/kb/kbaseTreechart.js
@@ -4,676 +4,703 @@ var d3 = require('d3');
 
 module.exports = KBWidget({
 
-  name: "kbaseTreechart",
-  parent: "kbaseVisWidget",
+    name: "kbaseTreechart",
+    parent: "kbaseVisWidget",
 
-  version: "1.0.0",
-  options: {
-    debug: true,
+    version: "1.0.0",
+    options: {
+        debug: true,
 
-    xGutter: 0,
-    xPadding: 0,
-    yGutter: 0,
-    yPadding: 0,
+        xGutter: 0,
+        xPadding: 0,
+        yGutter: 0,
+        yPadding: 0,
 
-    bgColor: 'none',
+        bgColor: 'none',
 
-    red: undefined,
-    blue: undefined,
+        red: undefined,
+        blue: undefined,
 
-    distance: 100,
+        distance: 100,
 
-    redBlue: false,
+        redBlue: false,
 
-    strokeWidth: 1.5,
-    transitionTime: 500,
-    lineStyle: 'curve', // curve / straight / square / step
+        strokeWidth: 1.5,
+        transitionTime: 500,
+        lineStyle: 'curve', // curve / straight / square / step
 
-    fixed: 0,
-    displayStyle: 'NTnt',
+        fixed: 0,
+        displayStyle: 'NTnt',
 
-    nodeHeight: 15,
-    labelSpace: 10,
-    circleRadius: 4.5,
-    circleStroke: 'steelblue',
-    openCircleFill: 'lightsteelblue',
-    closedCircleFill: '#FFF',
-    staticWidth : false,
-    staticHeight : false,
+        nodeHeight: 15,
+        labelSpace: 10,
+        circleRadius: 4.5,
+        circleStroke: 'steelblue',
+        openCircleFill: 'lightsteelblue',
+        closedCircleFill: '#FFF',
+        staticWidth : false,
+        staticHeight : false,
+        canShrinkWidth : true,
 
-  },
+    },
 
-  _accessors: [
-    'comparison',
-  ],
+    _accessors: [
+        'comparison',
+    ],
 
-  afterInArray: function (val, array) {
-    var idx = array.indexOf(val) + 1;
-    if (idx >= array.length) {
-      idx = 0;
-    }
-
-    return array[idx];
-  },
-
-  countVisibleNodes: function (nodes) {
-    var num = 1;
-    if (nodes.children != undefined && (nodes.open == true || nodes.open == undefined)) {
-      for (var idx = 0; idx < nodes.children.length; idx++) {
-        num += this.countVisibleNodes(nodes.children[idx]);
-      }
-    }
-
-    return num;
-  },
-
-  findInChildren: function (target, search) {
-    if (target == search) {
-      return true;
-    }
-    if (search != undefined && search.children != undefined) {
-      for (var idx = 0; idx < search.children.length; idx++) {
-        if (this.findInChildren(target, search.children[idx])) {
-          return true;
+    afterInArray: function (val, array) {
+        var idx = array.indexOf(val) + 1;
+        if (idx >= array.length) {
+            idx = 0;
         }
-      }
-    }
 
-    return false;
-  },
+        return array[idx];
+    },
 
-  redBlue: function (node, d) {
-    var $tree = this;
-    if ($tree.options.red == d) {
-      $tree.options.red = undefined;
-      $tree.options.redNode = undefined;
-    }
-
-    if ($tree.options.blue == d) {
-      $tree.options.blue = undefined;
-      $tree.options.blueNode = undefined;
-    }
-
-    var colors = ['red', 'black'];
-
-    if ($tree.options.red != undefined && $tree.options.blue != undefined) {
-      $tree.options.red.fill = 'black';
-      d3.select($tree.options.redNode).attr('fill', $tree.options.red.fill);
-      $tree.options.red = undefined;
-      colors = ['red', 'black'];
-    }
-    else if ($tree.options.red != undefined) {
-      colors = ['blue', 'black'];
-    }
-
-    else if ($tree.options.red == undefined && $tree.options.blue != undefined) {
-      colors = ['red', 'black'];
-    }
-
-    d.fill = $tree.afterInArray(d.fill, colors);
-
-    if (d.fill != 'black' && d.children != undefined
-      && !$tree.findInChildren($tree.options.red, d) && !$tree.findInChildren($tree.options.blue, d)) {
-
-      $tree.toggle(d);
-      $tree.updateTree(d);
-
-    }
-
-    if (d.fill != 'black') {
-      $tree.options[d.fill] = d;
-      $tree.options[d.fill + 'Node'] = node;
-    }
-
-    d3.select(node).attr('fill', d.fill);
-
-    if ($tree.options.red != undefined && $tree.options.blue != undefined) {
-      $tree.comparison('Comparing ' + $tree.options.red.name + ' vs ' + $tree.options.blue.name);
-    }
-    else {
-      $tree.comparison('');
-    }
-  },
-
-  defaultNodeClick : function(d) {
-    if (!this.findInChildren(this.options.red, d) && !this.findInChildren(this.options.blue, d)) {
-        this.toggle(d);
-        this.updateTree(d);
-    }
-  },
-
-  defaultTextClick : function(d, node) {
-
-
-      if (this.options.redBlue) {
-        this.redBlue(node, d);
-      }
-
-  },
-
-    nodeState : function(d) {
-        if (d.children) {
-            return 'open';
+    countVisibleNodes: function (nodes) {
+        var num = 1;
+        if (nodes.children != undefined && (nodes.open == true || nodes.open == undefined)) {
+            for (var idx = 0; idx < nodes.children.length; idx++) {
+                num += this.countVisibleNodes(nodes.children[idx]);
+            }
         }
-        else if (d._children) {
-            return 'closed';
+
+        return num;
+    },
+
+    findInChildren: function (target, search) {
+        if (target == search) {
+            return true;
+        }
+        if (search != undefined && search.children != undefined) {
+            for (var idx = 0; idx < search.children.length; idx++) {
+                if (this.findInChildren(target, search.children[idx])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    },
+
+    redBlue: function (node, d) {
+        var $tree = this;
+        if ($tree.options.red == d) {
+            $tree.options.red = undefined;
+            $tree.options.redNode = undefined;
+        }
+
+        if ($tree.options.blue == d) {
+            $tree.options.blue = undefined;
+            $tree.options.blueNode = undefined;
+        }
+
+        var colors = ['red', 'black'];
+
+        if ($tree.options.red != undefined && $tree.options.blue != undefined) {
+            $tree.options.red.fill = 'black';
+            d3.select($tree.options.redNode).attr('fill', $tree.options.red.fill);
+            $tree.options.red = undefined;
+            colors = ['red', 'black'];
+        }
+        else if ($tree.options.red != undefined) {
+            colors = ['blue', 'black'];
+        }
+
+        else if ($tree.options.red == undefined && $tree.options.blue != undefined) {
+            colors = ['red', 'black'];
+        }
+
+        d.fill = $tree.afterInArray(d.fill, colors);
+
+        if (d.fill != 'black' && d.children != undefined
+            && !$tree.findInChildren($tree.options.red, d) && !$tree.findInChildren($tree.options.blue, d)) {
+
+            $tree.toggle(d);
+            $tree.updateTree(d);
+
+        }
+
+        if (d.fill != 'black') {
+            $tree.options[d.fill] = d;
+            $tree.options[d.fill + 'Node'] = node;
+        }
+
+        d3.select(node).attr('fill', d.fill);
+
+        if ($tree.options.red != undefined && $tree.options.blue != undefined) {
+            $tree.comparison('Comparing ' + $tree.options.red.name + ' vs ' + $tree.options.blue.name);
         }
         else {
-            return 'leaf';
+            $tree.comparison('');
         }
     },
 
-  depth : function(d, rootOffset, chartOffset) {
-    if (this.options.depth) {
-        return this.options.depth.call(this, d, rootOffset, chartOffset);
-    }
-    else {
-        return this.defaultDepth(d, rootOffset, chartOffset);
-    }
-  },
-
-  defaultDepth : function(d, rootOffset, chartOffset) {
-
-      var distance = this.options.distance;
-      if (d.distance != undefined) {
-        distance *= d.distance;
-      }
-      ;
-
-      if (d.parent != undefined) {
-        distance += this.depth(d.parent, rootOffset, chartOffset);
-      }
-      else {
-        distance = rootOffset + chartOffset;
-      }
-
-      return distance;
+    defaultNodeClick : function(d) {
+        if (!this.findInChildren(this.options.red, d) && !this.findInChildren(this.options.blue, d)) {
+                this.toggle(d);
+                this.updateTree(d);
+        }
     },
 
-  updateTree: function (source) {
-    var chart = this.data('D3svg').select(this.region('chart'));
-
-    var $tree = this;
-
-    var duration = this.initialized ? this.options.transitionTime : 0;
-
-    var rootOffset = 0;
-
-    var bounds = this.chartBounds();
-
-    //okay. This is going to suck. Figure out the appropriate depth of the root element. Create a fake SVG element,
-    // toss the root node into there, and yank out its width.
-    var fakeDiv = document.createElement('div');
-
-    var root = source;
-    while (root.parent != undefined) {
-      root = root.parent;
-    }
-
-    var rootText = chart.append('text')
-      .attr('style', 'visibility : hidden; font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
-      .attr('class', 'fake')
-      .text(root.name);
-    rootOffset = rootText[0][0].getBBox().width + $tree.options.labelSpace + bounds.origin.x;
-
-    var newHeight = this.options.nodeHeight * this.countVisibleNodes(this.dataset());
-    //this.$elem.animate({'height' : newHeight + this.options.yGutter + this.options.yPadding}, 500);
-    //            this.$elem.height(newHeight);
-    this.height(this.$elem.height());
-    bounds.size.height = newHeight;
-    this.treeLayout = this.layoutType()
-      .size([bounds.size.height, bounds.size.width]);
+    defaultTextClick : function(d, node) {
 
 
-    this.nodes = this.treeLayout.nodes(this.dataset()).reverse();
+            if (this.options.redBlue) {
+                this.redBlue(node, d);
+            }
 
-    var chartOffset = 0;
+    },
 
+        nodeState : function(d) {
+                if (d.children) {
+                        return 'open';
+                }
+                else if (d._children) {
+                        return 'closed';
+                }
+                else {
+                        return 'leaf';
+                }
+        },
 
+    depth : function(d, rootOffset, chartOffset) {
+        if (this.options.depth) {
+                return this.options.depth.call(this, d, rootOffset, chartOffset);
+        }
+        else {
+                return this.defaultDepth(d, rootOffset, chartOffset);
+        }
+    },
 
-    var maxOffset = 0;
-    var minOffset = 5000000000;
+    defaultDepth : function(d, rootOffset, chartOffset) {
 
-    function findWidth(text, d) {
-      var box = text[0][0].getBBox();
-      var right = d.children || d._children
-        ? d.y + $tree.options.labelSpace
-        : d.y + box.width + $tree.options.labelSpace;
-      var left = d.children || d._children
-        ? d.y + $tree.options.labelSpace - box.width
-        : d.y + $tree.options.labelSpace;
+            var distance = this.options.distance;
+            if (d.distance != undefined) {
+                distance *= d.distance;
+            }
+            ;
 
-      return [left, right, right - left];
-    }
+            if (d.parent != undefined) {
+                distance += this.depth(d.parent, rootOffset, chartOffset);
+            }
+            else {
+                distance = rootOffset + chartOffset;
+            }
 
-    this.nodes.forEach(
-      function (d) {
-        d.y = $tree.depth(d, rootOffset, chartOffset);
+            return distance;
+        },
 
-        if (d.name == undefined && $tree.options.nameFunction) {
-          d.name = $tree.options.nameFunction.call($tree, d);
+    updateTree: function (source) {
+        var chart = this.data('D3svg').select(this.region('chart'));
+
+        var $tree = this;
+
+        var duration = this.initialized ? this.options.transitionTime : 0;
+
+        var rootOffset = 0;
+
+        var bounds = this.chartBounds();
+
+        //okay. This is going to suck. Figure out the appropriate depth of the root element. Create a fake SVG element,
+        // toss the root node into there, and yank out its width.
+        var fakeDiv = document.createElement('div');
+
+        var root = source;
+        while (root.parent != undefined) {
+            root = root.parent;
         }
 
-        var fakeText = chart.append('text')
-          .attr('style', 'visibility : hidden;font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
-          .attr('class', 'fake')
-          .text(d.name);
+        var rootText = chart.append('text')
+            .attr('style', 'visibility : hidden; font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
+            .attr('class', 'fake')
+            .text(root.name);
+        rootOffset = rootText[0][0].getBBox().width + $tree.options.labelSpace + bounds.origin.x;
 
-        var fakeBounds = findWidth(fakeText, d);
-        var fakeLeft = fakeBounds[0];
-        var fakeRight = fakeBounds[1];
-        d.width = fakeBounds[2];
+        var newHeight = this.options.nodeHeight * this.countVisibleNodes(this.dataset());
+        //this.$elem.animate({'height' : newHeight + this.options.yGutter + this.options.yPadding}, 500);
+        //            this.$elem.height(newHeight);
+        this.height(this.$elem.height());
+        bounds.size.height = newHeight;
+        this.treeLayout = this.layoutType()
+            .size([bounds.size.height, bounds.size.width]);
 
-        if ($tree.options.labelWidth && d.width > $tree.options.labelWidth) {
-          var words = d.name.split(/\s+/);
-          var shortWords = [words.shift()];
 
-          fakeText.text(shortWords.join(' '));
-          var throttle = 0
-          while (findWidth(fakeText, d)[2] < $tree.options.labelWidth && throttle++ < 40) {
-            shortWords.push(words.shift());
-            fakeText.text(shortWords.join(' '));
-          }
+        this.nodes = this.treeLayout.nodes(this.dataset()).reverse();
 
-          words.push(shortWords.pop());
+        var chartOffset = 0;
 
-          d.name_truncated = shortWords.join(' ');
 
+
+        var maxOffset = 0;
+        var minOffset = 5000000000;
+
+        function findWidth(text, d) {
+            var box = text[0][0].getBBox();
+            var right = d.children || d._children
+                ? d.y + $tree.options.labelSpace
+                : d.y + box.width + $tree.options.labelSpace;
+            var left = d.children || d._children
+                ? d.y + $tree.options.labelSpace - box.width
+                : d.y + $tree.options.labelSpace;
+
+            return [left, right, right - left];
         }
 
-        if (fakeRight > maxOffset) {
-          maxOffset = fakeRight;
-        }
+        $tree.options.fixedDepth = 0;
 
-        if (fakeLeft < minOffset) {
-          minOffset = fakeLeft;
-        }
+        this.nodes.forEach(
+            function (d) {
+                d.y = $tree.depth(d, rootOffset, chartOffset);
 
-      }
-    );
-
-    var widthDelta = 0;
-    if (minOffset < bounds.origin.x) {
-      widthDelta += bounds.origin.x - minOffset;
-      chartOffset = widthDelta;
-    }
-    if (maxOffset > bounds.origin.x + bounds.size.width) {
-      widthDelta += maxOffset - bounds.size.width;
-    }
-
-    $tree.options.fixedDepth = 0;
-
-    this.nodes.forEach(
-      function (d) {
-        d.y = $tree.depth(d, rootOffset, chartOffset);
-
-        if (d.y > $tree.options.fixedDepth) {
-          $tree.options.fixedDepth = d.y;
-        }
-      }
-    );
-
-    chart.selectAll('.fake').remove();
-
-    var newWidth = this.options.xGutter + this.options.yGutter + widthDelta + bounds.size.width;
-    if (newWidth < $tree.options.originalWidth) {
-      newWidth = $tree.options.originalWidth;
-    }
-
-    newWidth = this.options.staticWidth ? this.$elem.width() : newWidth;
-    newHeight = this.options.staticHeight ? this.$elem.height() : newHeight + this.options.yGutter + this.options.yPadding;
-
-        this.$elem.animate(
-          {
-            'width': newWidth,
-            'height': newHeight
-          },
-          duration
+                if (d.y > $tree.options.fixedDepth) {
+                    $tree.options.fixedDepth = d.y;
+                }
+            }
         );
 
-    var node = chart.selectAll("g.node")
-      .data(this.nodes, this.uniqueID);
+        this.nodes.forEach(
+            function (d) {
+                d.y = $tree.depth(d, rootOffset, chartOffset);
 
-    // Enter any new nodes at the parent's previous position.
-    var nodeEnter = node.enter().append("g")
-        .attr("class", "node")
-        .attr("transform", function (d) { return "translate(" + source.y0 + "," + source.x0 + ")"; })
-      ;
+                d.y = $tree.options.fixed && (!d.children || d.children.length == 0)
+                    ? $tree.options.fixedDepth
+                    : d.y;
 
-            nodeEnter.append("circle")
-                .attr("r", 1e-6)
-                .attr('style', 'cursor : pointer;')
-                .attr('stroke', function(d) { return d.stroke || $tree.options.circleStroke})
-                .style("fill", function(d) { return d._children ? $tree.options.openCircleFill : $tree.options.closedCircleFill; })
-                .on("click", function(d) {
+                if (d.name == undefined && $tree.options.nameFunction) {
+                    d.name = $tree.options.nameFunction.call($tree, d);
+                }
 
-        if ($tree.oneClick) {
+                var fakeText = chart.append('text')
+                    .attr('style', 'visibility : hidden;font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
+                    .attr('class', 'fake')
+                    .text(d.name);
 
-          if ($tree.options.nodeDblClick) {
-            $tree.oneClick = false;
-            $tree.options.nodeDblClick.call($tree, d, this);
-          }
-        }
-        else {
-          $tree.oneClick = true;
-          setTimeout($.proxy(function () {
-            if ($tree.oneClick) {
-              $tree.oneClick = false;
-              if ($tree.options.nodeClick) {
-                return $tree.options.nodeClick.call($tree, d, this);
-              }
-              else {
-                $tree.defaultNodeClick(d, this);
-              }
-            }
-          }, this), 250)
-        }
+                var fakeBounds = findWidth(fakeText, d);
+                var fakeLeft = fakeBounds[0];
+                var fakeRight = fakeBounds[1];
+                d.width = fakeBounds[2];
 
-      })
-      .on('mouseover', function (d) {
-        if ($tree.options.tooltip) {
-          $tree.options.tooltip.call($tree, d);
-        }
-        else if (d.tooltip) {
-          $tree.showToolTip({label: d.tooltip})
-        }
-      })
-      .on('mouseout', function (d) {
-        $tree.hideToolTip()
-      })
-    ;
+                if ($tree.options.labelWidth && d.width > $tree.options.labelWidth) {
+                    var words = d.name.split(/\s+/);
+                    var shortWords = [words.shift()];
 
-    nodeEnter.append("text")
-      //.attr('style', 'font-size : 11px')
-      .attr('style', 'font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
-      .attr("dy", ".35em")
-      .text(function (d) {
-        var name = d.name;
-        if (d.width > $tree.options.labelWidth && $tree.options.truncationFunction) {
-          name = $tree.options.truncationFunction(d, this, $tree);
-        }
-        return name;
-      })
-      .style("fill-opacity", 1e-6)
-      .attr('fill', function (d) { return d.fill || 'black'})
-      .on("click", function (d) {
-
-        if ($tree.oneClick) {
-
-          if ($tree.options.textDblClick) {
-            $tree.oneClick = false;
-            $tree.options.textDblClick.call($tree, d, this);
-          }
-        }
-        else {
-          $tree.oneClick = true;
-          setTimeout($.proxy(function () {
-            if ($tree.oneClick) {
-              $tree.oneClick = false;
-              if ($tree.options.textClick) {
-                return $tree.options.textClick.call($tree, d, this);
-              }
-              else {
-                return $tree.defaultTextClick(d, this);
-              }
-            }
-          }, this), 250)
-        }
-
-      })
-
-    ;
-
-    nodeEnter.each(function (d, i) {
-      if ($tree.options.nodeEnterCallback) {
-        $tree.options.nodeEnterCallback.call($tree, d, i, this, duration);
-      }
-    });
-
-
-    // Transition nodes to their new position.
-    var nodeUpdate = node.transition()
-        .duration(duration)
-        .attr("transform", function (d) {
-          var y = $tree.options.fixed && (!d.children || d.length == 0)
-            ? $tree.options.fixedDepth
-            : d.y;
-          return "translate(" + y + "," + d.x + ")";
-        })
-      ;
-
-    nodeUpdate.select("circle")
-      .attr("r", $tree.options.circleRadius)
-      .attr('stroke', function (d) { return d.stroke || $tree.options.circleStroke})
-      .style("fill", function (d) { return d._children ? $tree.options.openCircleFill : $tree.options.closedCircleFill; })
-
-      .attr('visibility', function (d) {
-        var isLeaf = true;
-        if (d.children && d.children.length) {
-          isLeaf = false;
-        }
-
-        if (isLeaf && $tree.options.displayStyle.match(/n/)) {
-          return 'visible';
-        }
-        else if (!isLeaf && $tree.options.displayStyle.match(/N/)) {
-          return 'visible';
-        }
-        else {
-          return 'hidden';
-        }
-      });
-
-    nodeUpdate.select("text")
-      .style("fill-opacity", 1)
-      .attr("x", function (d) { return d.children ? 0 - $tree.options.labelSpace : $tree.options.labelSpace; })
-      .attr("text-anchor", function (d) { return d.children ? "end" : "start"; })
-      .attr('visibility', function (d) {
-        var isLeaf = true;
-        if (d.children && d.children.length) {
-          isLeaf = false;
-        }
-
-        if (isLeaf && $tree.options.displayStyle.match(/t/)) {
-          return 'visible';
-        }
-        else if (!isLeaf && $tree.options.displayStyle.match(/T/)) {
-          return 'visible';
-        }
-        else {
-          return 'hidden';
-        }
-      });
-
-    nodeUpdate.each(function (d, i) {
-      if ($tree.options.nodeUpdateCallback) {
-        $tree.options.nodeUpdateCallback.call($tree, d, i, this, duration);
-      }
-    });
-
-    // Transition exiting nodes to the parent's new position.
-    var nodeExit = node.exit().transition()
-        .duration(duration)
-        .attr("transform", function (d) { return "translate(" + source.y + "," + source.x + ")"; })
-        .remove()
-      ;
-
-    nodeExit.select("circle")
-      .attr("r", 1e-6);
-
-    nodeExit.select("text")
-      .style("fill-opacity", 1e-6);
-
-    nodeExit.each(function (d, i) {
-      if ($tree.options.nodeExitCallback) {
-        $tree.options.nodeExitCallback.call($tree, d, i, this, duration);
-      }
-    });
-
-    // Update the links�
-    var link = chart.selectAll("path.link")
-      .data($tree.treeLayout.links($tree.nodes), function (d) { return d.target.id; });
-
-            // Enter any new links at the parent's previous position.
-            link.enter().insert("path", "g")
-                .attr("class", "link")
-                .attr('fill', 'none')
-                .attr('stroke', '#ccc')
-                .attr("d", function(d) {
-                  var o = {x: source.x0, y: source.y0};
-                  return $tree.diagonal({source: o, target: o});
-                })
-            .transition()
-                .duration(duration)
-                .attr("d", $tree.diagonal);
-
-            // Transition links to their new position.
-            link.transition()
-                .duration(duration)
-                .attr('stroke-width', function (d) {
-                    var weight = d.target.weight || $tree.options.strokeWidth;
-                    if (typeof(weight) === 'function') {
-                        weight = weight.call($tree, d);
+                    fakeText.text(shortWords.join(' '));
+                    var throttle = 0
+                    while (findWidth(fakeText, d)[2] < $tree.options.labelWidth && throttle++ < 40) {
+                        shortWords.push(words.shift());
+                        fakeText.text(shortWords.join(' '));
                     }
 
-                    return weight + 'px';
-                })
-                .attr("d", $tree.diagonal);
+                    words.push(shortWords.pop());
 
-    // Transition exiting nodes to the parent's new position.
-    link.exit().transition()
-      .duration(duration)
-      .attr("d", function (d) {
-        var o = {x: source.x, y: source.y};
-        return $tree.diagonal({source: o, target: o});
-      })
-      .remove();
+                    d.name_truncated = shortWords.join(' ');
 
-    // Stash the old positions for transition.
-    $tree.nodes.forEach(function (d) {
-      d.x0 = d.x;
-      d.y0 = d.y;
-    });
+                }
 
+                if (fakeRight > maxOffset) {
+                    maxOffset = fakeRight;
+                }
 
-  },
+                if (fakeLeft < minOffset) {
+                    minOffset = fakeLeft;
+                }
 
-  layoutType: function () {
-    if (this.options.layout == 'cluster') {
-      return d3.layout.cluster()
-    }
-    else if (this.options.layout == undefined) {
-      return d3.layout.tree();
-    }
-    else {
-      return this.options.layout;
-    }
-  },
+            }
+        );
 
-  renderChart: function () {
-
-    if (this.dataset() == undefined) {
-      return;
-    }
-
-    //            this.$elem.height(30 * this.countVisibleNodes(this.dataset()));
-    //            this.height(this.$elem.height());
-
-    this.options.originalWidth = this.$elem.width();
-
-    var i = 0;
-    var bounds = this.chartBounds();
-
-    if (this.treeLayout == undefined) {
-      this.treeLayout = this.layoutType()
-        .size([bounds.size.height, bounds.size.width]);
-    }
-
-    var $tree = this;
-
-    if (this.options.lineStyle == 'curve') {
-      this.diagonal = d3.svg.diagonal()
-        .projection(function (d) {
-          var y = $tree.options.fixed && (!d.children || d.length == 0)
-            ? $tree.options.fixedDepth
-            : d.y;
-          return [y, d.x];
-        });
-    }
-    else if (this.options.lineStyle == 'straight') {
-      this.diagonal = function (d) {
-
-        var y = $tree.options.fixed && (!d.target.children || d.target.length == 0)
-          ? $tree.options.fixedDepth
-          : d.target.y;
-
-        return "M" + d.source.y + ',' + d.source.x + 'L' + y + ',' + d.target.x;
-      }
-    }
-    else if (this.options.lineStyle == 'square') {
-      this.diagonal = function (d) {
-
-        var y = $tree.options.fixed && (!d.target.children || d.target.length == 0)
-          ? $tree.options.fixedDepth
-          : d.target.y;
-
-        return "M" + d.source.y + ',' + d.source.x +
-          'L' + d.source.y + ',' + d.target.x +
-          'L' + y + ',' + d.target.x
-          ;
-      }
-    }
-    else if (this.options.lineStyle == 'step') {
-      this.diagonal = function (d) {
-
-        var y = $tree.options.fixed && (!d.target.children || d.target.length == 0)
-          ? $tree.options.fixedDepth
-          : d.target.y;
-
-        var halfY = (y - d.source.y ) / 2 + d.source.y;
-
-        return "M" + d.source.y + ',' + d.source.x +
-          'L' + halfY + ',' + d.source.x +
-          'L' + halfY + ',' + d.target.x +
-          'L' + y + ',' + d.target.x
-          ;
-      }
-    }
-
-    // Compute the new tree layout.
-    this.nodes = this.treeLayout.nodes(this.dataset()).reverse();
-
-    this.dataset().x0 = bounds.size.height / 2;
-    this.dataset().y0 = 0;
-
-    function toggleAll(d) {
-      if (d.children) {
-        d.children.forEach(toggleAll);
-        if (d.open == false) {
-          $tree.toggle(d);
+        var widthDelta = 0;
+        if (minOffset < bounds.origin.x) {
+            widthDelta += bounds.origin.x - minOffset;
+            chartOffset = widthDelta;
         }
-      }
-    }
+        if (maxOffset > bounds.origin.x + bounds.size.width) {
+            widthDelta += maxOffset - bounds.size.width;
+        }
 
-    var root = this.dataset();
-    root.children.forEach(toggleAll);
+        chart.selectAll('.fake').remove();
+
+        var newWidth = this.options.xGutter + this.options.yGutter + widthDelta + bounds.size.width;
+
+        if (newWidth < $tree.options.originalWidth && ! $tree.options.canShrinkWidth) {
+            newWidth = $tree.options.originalWidth;
+        }
+
+        newWidth = this.options.staticWidth ? $tree.options.originalWidth : newWidth;
+        newHeight = this.options.staticHeight ? $tree.options.originalHeight : newHeight + this.options.yGutter + this.options.yPadding;
+
+                this.$elem.animate(
+                    {
+                        'width': newWidth,
+                        'height': newHeight
+                    },
+                    duration
+                );
+
+        var uniqueness = function (d) {
+
+            if (d.id == undefined) {
+
+                var name = d.name;
+                if (name == undefined && $tree.options.nameFunction != undefined) {
+                    name = $tree.options.nameFunction.call($tree, d);
+                }
+
+                if (d.parent != undefined) {
+                    name = uniqueness(d.parent) + '/' + name;
+                }
+
+                d.id = name;
+            }
+
+            return d.id;
+
+        }
+
+        var node = chart.selectAll("g.node")
+            .data(this.nodes, uniqueness);
+
+        // Enter any new nodes at the parent's previous position.
+        var nodeEnter = node.enter().append("g")
+                .attr("class", "node")
+                .attr("transform", function (d) { return "translate(" + source.y0 + "," + source.x0 + ")"; })
+            ;
+
+                        nodeEnter.append("circle")
+                                .attr("r", 1e-6)
+                                .attr('style', 'cursor : pointer;')
+                                .attr('stroke', function(d) { return d.stroke || $tree.options.circleStroke})
+                                .style("fill", function(d) { return d._children ? $tree.options.openCircleFill : $tree.options.closedCircleFill; })
+                                .on("click", function(d) {
+
+                if ($tree.oneClick) {
+
+                    if ($tree.options.nodeDblClick) {
+                        $tree.oneClick = false;
+                        $tree.options.nodeDblClick.call($tree, d, this);
+                    }
+                }
+                else {
+                    $tree.oneClick = true;
+                    setTimeout($.proxy(function () {
+                        if ($tree.oneClick) {
+                            $tree.oneClick = false;
+                            if ($tree.options.nodeClick) {
+                                return $tree.options.nodeClick.call($tree, d, this);
+                            }
+                            else {
+                                $tree.defaultNodeClick(d, this);
+                            }
+                        }
+                    }, this), 250)
+                }
+
+            })
+            .on('mouseover', function (d) {
+                if ($tree.options.tooltip) {
+                    $tree.options.tooltip.call($tree, d);
+                }
+                else if (d.tooltip) {
+                    $tree.showToolTip({label: d.tooltip})
+                }
+            })
+            .on('mouseout', function (d) {
+                $tree.hideToolTip()
+            })
+        ;
+
+        nodeEnter.append("text")
+            //.attr('style', 'font-size : 11px')
+            .attr('style', 'font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
+            .attr("dy", ".35em")
+            .text(function (d) {
+                var name = d.name;
+                if (d.width > $tree.options.labelWidth && $tree.options.truncationFunction) {
+                    name = $tree.options.truncationFunction(d, this, $tree);
+                }
+                return name;
+            })
+            .style("fill-opacity", 1e-6)
+            .attr('fill', function (d) { return d.fill || 'black'})
+            .on("click", function (d) {
+
+                if ($tree.oneClick) {
+
+                    if ($tree.options.textDblClick) {
+                        $tree.oneClick = false;
+                        $tree.options.textDblClick.call($tree, d, this);
+                    }
+                }
+                else {
+                    $tree.oneClick = true;
+                    setTimeout($.proxy(function () {
+                        if ($tree.oneClick) {
+                            $tree.oneClick = false;
+                            if ($tree.options.textClick) {
+                                return $tree.options.textClick.call($tree, d, this);
+                            }
+                            else {
+                                return $tree.defaultTextClick(d, this);
+                            }
+                        }
+                    }, this), 250)
+                }
+
+            })
+
+        ;
+
+        nodeEnter.each(function (d, i) {
+            if ($tree.options.nodeEnterCallback) {
+                $tree.options.nodeEnterCallback.call($tree, d, i, this, duration);
+            }
+        });
 
 
-    this.updateTree(this.dataset());
-    this.initialized = true;
-  },
+        // Transition nodes to their new position.
+        var nodeUpdate = node.transition()
+                .duration(duration)
+                .attr("transform", function (d) {
+                    var y = $tree.options.fixed && (!d.children || d.length == 0)
+                        ? $tree.options.fixedDepth
+                        : d.y;
+                    return "translate(" + y + "," + d.x + ")";
+                })
+            ;
+
+        nodeUpdate.select("circle")
+            .attr("r", $tree.options.circleRadius)
+            .attr('stroke', function (d) { return d.stroke || $tree.options.circleStroke})
+            .style("fill", function (d) { return d._children ? $tree.options.openCircleFill : $tree.options.closedCircleFill; })
+
+            .attr('visibility', function (d) {
+                var isLeaf = true;
+                if (d.children && d.children.length) {
+                    isLeaf = false;
+                }
+
+                if (isLeaf && $tree.options.displayStyle.match(/n/)) {
+                    return 'visible';
+                }
+                else if (!isLeaf && $tree.options.displayStyle.match(/N/)) {
+                    return 'visible';
+                }
+                else {
+                    return 'hidden';
+                }
+            });
+
+        nodeUpdate.select("text")
+            .style("fill-opacity", 1)
+            .attr("x", function (d) { return d.children ? 0 - $tree.options.labelSpace : $tree.options.labelSpace; })
+            .attr("text-anchor", function (d) { return d.children ? "end" : "start"; })
+            .attr('visibility', function (d) {
+                var isLeaf = true;
+                if (d.children && d.children.length) {
+                    isLeaf = false;
+                }
+
+                if (isLeaf && $tree.options.displayStyle.match(/t/)) {
+                    return 'visible';
+                }
+                else if (!isLeaf && $tree.options.displayStyle.match(/T/)) {
+                    return 'visible';
+                }
+                else {
+                    return 'hidden';
+                }
+            });
+
+        nodeUpdate.each(function (d, i) {
+            if ($tree.options.nodeUpdateCallback) {
+                $tree.options.nodeUpdateCallback.call($tree, d, i, this, duration);
+            }
+        });
+
+        // Transition exiting nodes to the parent's new position.
+        var nodeExit = node.exit().transition()
+                .duration(duration)
+                .attr("transform", function (d) { return "translate(" + source.y + "," + source.x + ")"; })
+                .remove()
+            ;
+
+        nodeExit.select("circle")
+            .attr("r", 1e-6);
+
+        nodeExit.select("text")
+            .style("fill-opacity", 1e-6);
+
+        nodeExit.each(function (d, i) {
+            if ($tree.options.nodeExitCallback) {
+                $tree.options.nodeExitCallback.call($tree, d, i, this, duration);
+            }
+        });
+
+        // Update the links�
+        var link = chart.selectAll("path.link")
+            .data($tree.treeLayout.links($tree.nodes), function(d) { return uniqueness(d.target) });
+
+                        // Enter any new links at the parent's previous position.
+                        link.enter().insert("path", "g")
+                                .attr("class", "link")
+                                .attr('fill', 'none')
+                                .attr('stroke', '#ccc')
+                                .attr("d", function(d) {
+                                    var o = {x: source.x0, y: source.y0};
+                                    return $tree.diagonal({source: o, target: o});
+                                })
+                        .transition()
+                                .duration(duration)
+                                .attr("d", $tree.diagonal);
+
+                        // Transition links to their new position.
+                        link.transition()
+                                .duration(duration)
+                                .attr('stroke-width', function (d) {
+                                        var weight = d.target.weight || $tree.options.strokeWidth;
+                                        if (typeof(weight) === 'function') {
+                                                weight = weight.call($tree, d);
+                                        }
+
+                                        return weight + 'px';
+                                })
+                                .attr("d", $tree.diagonal);
+
+        // Transition exiting nodes to the parent's new position.
+        link.exit().transition()
+            .duration(duration)
+            .attr("d", function (d) {
+                var o = {x: source.x, y: source.y};
+                return $tree.diagonal({source: o, target: o});
+            })
+            .remove();
+
+        // Stash the old positions for transition.
+        $tree.nodes.forEach(function (d) {
+            d.x0 = d.x;
+            d.y0 = d.y;
+        });
 
 
-  toggle: function (d) {
-    if (d.children != undefined) {
-      d._children = d.children;
-      d.children = null;
-    } else {
-      d.children = d._children;
-      d._children = null;
+    },
 
-    }
-  },
+    layoutType: function () {
+        if (this.options.layout == 'cluster') {
+            return d3.layout.cluster()
+        }
+        else if (this.options.layout == undefined) {
+            return d3.layout.tree();
+        }
+        else {
+            return this.options.layout;
+        }
+    },
+
+    renderChart: function () {
+
+        if (this.dataset() == undefined) {
+            return;
+        }
+
+        //            this.$elem.height(30 * this.countVisibleNodes(this.dataset()));
+        //            this.height(this.$elem.height());
+
+        this.options.originalWidth = this.$elem.width();
+        this.options.originalHeight = this.$elem.height();
+
+        var i = 0;
+        var bounds = this.chartBounds();
+
+        if (this.treeLayout == undefined) {
+            this.treeLayout = this.layoutType()
+                .size([bounds.size.height, bounds.size.width]);
+        }
+
+        var $tree = this;
+
+        if (this.options.lineStyle == 'curve') {
+            this.diagonal = d3.svg.diagonal()
+                .projection(function (d) {
+                    var y = $tree.options.fixed && (!d.children || d.length == 0)
+                        ? $tree.options.fixedDepth
+                        : d.y;
+                    return [y, d.x];
+                });
+        }
+        else if (this.options.lineStyle == 'straight') {
+            this.diagonal = function (d) {
+
+                var y = $tree.options.fixed && (!d.target.children || d.target.children.length == 0)
+                    ? $tree.options.fixedDepth
+                    : d.target.y;
+
+                return "M" + d.source.y + ',' + d.source.x + 'L' + y + ',' + d.target.x;
+            }
+        }
+        else if (this.options.lineStyle == 'square') {
+            this.diagonal = function (d) {
+
+                var y = $tree.options.fixed && (!d.target.children || d.target.children.length == 0)
+                    ? $tree.options.fixedDepth
+                    : d.target.y;
+
+                return "M" + d.source.y + ',' + d.source.x +
+                    'L' + d.source.y + ',' + d.target.x +
+                    'L' + y + ',' + d.target.x
+                    ;
+            }
+        }
+        else if (this.options.lineStyle == 'step') {
+            this.diagonal = function (d) {
+
+                var y = $tree.options.fixed && (!d.target.children || d.target.children.length == 0)
+                    ? $tree.options.fixedDepth
+                    : d.target.y;
+
+                var halfY = (y - d.source.y ) / 2 + d.source.y;
+
+                return "M" + d.source.y + ',' + d.source.x +
+                    'L' + halfY + ',' + d.source.x +
+                    'L' + halfY + ',' + d.target.x +
+                    'L' + y + ',' + d.target.x
+                    ;
+            }
+        }
+
+        // Compute the new tree layout.
+        this.nodes = this.treeLayout.nodes(this.dataset()).reverse();
+
+        this.dataset().x0 = bounds.size.height / 2;
+        this.dataset().y0 = 0;
+
+        function toggleAll(d) {
+            if (d.children) {
+                d.children.forEach(toggleAll);
+                if (d.open == false) {
+                    $tree.toggle(d);
+                }
+            }
+        }
+
+        var root = this.dataset();
+        root.children.forEach(toggleAll);
+
+
+        this.updateTree(this.dataset());
+        this.initialized = true;
+    },
+
+
+    toggle: function (d) {
+        if (d.children != undefined) {
+            d._children = d.children;
+            d.children = null;
+        } else {
+            d.children = d._children;
+            d._children = null;
+
+        }
+    },
 
 
 });

--- a/kb/kbaseTreechart.js
+++ b/kb/kbaseTreechart.js
@@ -38,6 +38,8 @@ module.exports = KBWidget({
     circleStroke: 'steelblue',
     openCircleFill: 'lightsteelblue',
     closedCircleFill: '#FFF',
+    staticWidth : false,
+    staticHeight : false,
 
   },
 
@@ -213,7 +215,6 @@ module.exports = KBWidget({
       .attr('class', 'fake')
       .text(root.name);
     rootOffset = rootText[0][0].getBBox().width + $tree.options.labelSpace + bounds.origin.x;
-    console.log("RO IS ", root, root.name, rootOffset, rootText[0][0].getBBox().width, $tree.options.labelSpace, bounds.origin.x);
 
     var newHeight = this.options.nodeHeight * this.countVisibleNodes(this.dataset());
     //this.$elem.animate({'height' : newHeight + this.options.yGutter + this.options.yPadding}, 500);
@@ -262,7 +263,7 @@ module.exports = KBWidget({
         var fakeLeft = fakeBounds[0];
         var fakeRight = fakeBounds[1];
         d.width = fakeBounds[2];
-console.log("CALCULATE WIDTH ON ", d.name, " TO BE ", d.width);
+
         if ($tree.options.labelWidth && d.width > $tree.options.labelWidth) {
           var words = d.name.split(/\s+/);
           var shortWords = [words.shift()];
@@ -319,13 +320,16 @@ console.log("CALCULATE WIDTH ON ", d.name, " TO BE ", d.width);
       newWidth = $tree.options.originalWidth;
     }
 
-    this.$elem.animate(
-      {
-        'width': newWidth,
-        'height': newHeight + this.options.yGutter + this.options.yPadding
-      },
-      duration
-    );
+    newWidth = this.options.staticWidth ? this.$elem.width() : newWidth;
+    newHeight = this.options.staticHeight ? this.$elem.height() : newHeight + this.options.yGutter + this.options.yPadding;
+
+        this.$elem.animate(
+          {
+            'width': newWidth,
+            'height': newHeight
+          },
+          duration
+        );
 
     var node = chart.selectAll("g.node")
       .data(this.nodes, this.uniqueID);

--- a/kb/kbaseTreechart.js
+++ b/kb/kbaseTreechart.js
@@ -9,12 +9,12 @@ module.exports = KBWidget({
 
     version: "1.0.0",
     options: {
-        debug: true,
+        debug: false,
 
         xGutter: 0,
         xPadding: 0,
-        yGutter: 0,
-        yPadding: 0,
+        yGutter: 2,
+        yPadding: 2,
 
         bgColor: 'none',
 
@@ -38,6 +38,9 @@ module.exports = KBWidget({
         circleStroke: 'steelblue',
         openCircleFill: 'lightsteelblue',
         closedCircleFill: '#FFF',
+
+        lineStroke : '#ccc',
+
         staticWidth : false,
         staticHeight : false,
         canShrinkWidth : true,
@@ -218,6 +221,7 @@ module.exports = KBWidget({
         rootOffset = rootText[0][0].getBBox().width + $tree.options.labelSpace + bounds.origin.x;
 
         var newHeight = this.options.nodeHeight * this.countVisibleNodes(this.dataset());
+
         //this.$elem.animate({'height' : newHeight + this.options.yGutter + this.options.yPadding}, 500);
         //            this.$elem.height(newHeight);
         this.height(this.$elem.height());
@@ -411,6 +415,7 @@ module.exports = KBWidget({
 
         nodeEnter.append("text")
             //.attr('style', 'font-size : 11px')
+            .attr('class', 'nodeText')
             .attr('style', 'font-size : 11px;cursor : pointer;-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;')
             .attr("dy", ".35em")
             .text(function (d) {
@@ -543,8 +548,9 @@ module.exports = KBWidget({
                         // Enter any new links at the parent's previous position.
                         link.enter().insert("path", "g")
                                 .attr("class", "link")
+                                .attr('data-node-id', function (d) { return uniqueness(d.target) } )
                                 .attr('fill', 'none')
-                                .attr('stroke', '#ccc')
+                                .attr('stroke', function (d) { return d.stroke || $tree.options.lineStroke})
                                 .attr("d", function(d) {
                                     var o = {x: source.x0, y: source.y0};
                                     return $tree.diagonal({source: o, target: o});

--- a/kb/kbaseVisWidget.js
+++ b/kb/kbaseVisWidget.js
@@ -813,13 +813,24 @@ KBWidget({
     var widgetWidth = this.width();
     var widgetHeight = this.height();
 
-    return new Rectangle(
+    var chart = new Rectangle(
       new Point(this.xPadding(), this.yGutter()),
       new Size(
         widgetWidth - this.xPadding() - this.xGutter(),
         widgetHeight - this.yGutter() - this.yPadding()
       )
     );
+
+    if (chart.size.width < 0) {
+        chart.size.width = 0;
+    }
+
+    if (chart.size.height < 0) {
+        chart.size.height = 0;
+    }
+
+    return chart;
+
   },
 
   showToolTip: function (args) {


### PR DESCRIPTION
- stopped the tree from re-scaling to be too wide for the page
- selections now persist after mouse up
- mousing over a genome view highlights the name and path in the tree
- path to selections remain highlighted
- changed param sent to geneselection callback : now {start : bin, end : bin}
