### PR TITLE
clicking changes

### DIFF
--- a/kb/WareTreeGeneDistribution.js
+++ b/kb/WareTreeGeneDistribution.js
@@ -59,7 +59,7 @@ module.exports = KBWidget({
             while (nodes.length) {
                 var nodeID = nodes.join('/');
 
-                $tree.data('D3svg').select($tree.region('chart')).selectAll('[data-node-id="' + nodeID + '"]')
+                $tree.data('D3svg').select($tree.region('chart')).selectAll('[data-link-id="' + nodeID + '"]')
                         .attr('stroke', $lgv.options.highlightColor)
 
                 nodes.pop();
@@ -84,7 +84,7 @@ module.exports = KBWidget({
             var relayout = function(d) {
 
                 delete d.depth;
-                delete d.id;
+                //delete d.id;
                 delete d.x;
                 delete d.x0;
                 delete d.y;
@@ -238,7 +238,7 @@ module.exports = KBWidget({
 
                     depth : function(d, rootOffset, chartOffset) {
                         if (d.parent == undefined) {
-                            return -5;
+                            return 5;
                         }
                         else {
                             return this.defaultDepth(d, rootOffset, chartOffset);
@@ -279,7 +279,48 @@ module.exports = KBWidget({
                         return d.name_truncated + '...';
                     },
 
+                    nodeOver : function(d, node) {
+                        this.options.tooltip.call(this, d);
+                        this.options.textOver.call(this, d, node);
+                    },
+
+                    nodeOut : function (d, node) {
+                        this.hideToolTip();
+                        this.options.textOut.call(this, d, node);
+                    },
+
+                    textOver : function (d, node) {
+                        //this has an -awful- hack and hardwires the highlight color to red.
+                        $wtgd.highlightTree(d, node.parentNode, { options : { highlightColor : 'red'} }, this);
+                    },
+
+                    textOut : function(d, node) {
+                        $wtgd.dehighlightTree(this);
+                    },
+
+
+
                     nodeClick : function(d, node) {
+                        //this.options.collapseTree.call(this,d,node);
+                        this.options.rerootTree.call(this, d, node);
+                    },
+
+                    textClick : function(d, node) {
+                        //this.options.collapseTree.call(this,d,node);
+                        this.options.rerootTree.call(this, d, node);
+                    },
+
+                    nodeDblClick : function(d, node) {
+                        //this.options.rerootTree.call(this, d, node);
+                        this.options.collapseTree.call(this, d, node);
+                    },
+
+                    textDblClick : function(d, node) {
+                        //this.options.rerootTree.call(this, d, node);
+                        this.options.collapseTree.call(this, d, node);
+                    },
+
+                    collapseTree : function(d, node) {
 
                         var oldState = this.nodeState(d);
 
@@ -300,15 +341,7 @@ module.exports = KBWidget({
 
                     },
 
-                    nodeDblClick : function(d, node) {
-                        this.options.textDblClick.call(this, d, node);
-                    },
-
-                    textClick : function(d) {
-
-                    },
-
-                    textDblClick : function(d, node) {
+                    rerootTree : function(d, node) {
 
                         var isRoot = true;
 
@@ -326,7 +359,7 @@ module.exports = KBWidget({
                             isRoot = false;
                         }
 
-                        if (this.nodeState(d) == 'open') {
+                        //if (this.nodeState(d) == 'open') {
                             relayout(d);
                             d.stroke = this.originalRoot ? 'cyan' : 'darkslateblue';
 
@@ -340,7 +373,7 @@ module.exports = KBWidget({
                                 $wtgd.options.treeRootChange.call(this, d);
                             }
 
-                        }
+                        //}
 
 
                     },

--- a/kb/kbaseTreechart.js
+++ b/kb/kbaseTreechart.js
@@ -401,15 +401,20 @@ module.exports = KBWidget({
 
             })
             .on('mouseover', function (d) {
-                if ($tree.options.tooltip) {
-                    $tree.options.tooltip.call($tree, d);
+                if ($tree.options.nodeOver) {
+                    $tree.options.nodeOver.call($tree, d, this);
                 }
                 else if (d.tooltip) {
                     $tree.showToolTip({label: d.tooltip})
                 }
             })
             .on('mouseout', function (d) {
-                $tree.hideToolTip()
+                if ($tree.options.nodeOut) {
+                    $tree.options.nodeOut.call($tree, d, this);
+                }
+                else if (d.tooltip) {
+                    $tree.hideToolTip()
+                }
             })
         ;
 
@@ -451,6 +456,16 @@ module.exports = KBWidget({
                     }, this), 250)
                 }
 
+            })
+            .on('mouseover', function (d) {
+                if ($tree.options.textOver) {
+                    $tree.options.textOver.call($tree, d, this);
+                }
+            })
+            .on('mouseout', function (d) {
+                if ($tree.options.textOut) {
+                    $tree.options.textOut.call($tree, d, this);
+                }
             })
 
         ;
@@ -548,7 +563,7 @@ module.exports = KBWidget({
                         // Enter any new links at the parent's previous position.
                         link.enter().insert("path", "g")
                                 .attr("class", "link")
-                                .attr('data-node-id', function (d) { return uniqueness(d.target) } )
+                                .attr('data-link-id', function (d) { return uniqueness(d.target) } )
                                 .attr('fill', 'none')
                                 .attr('stroke', function (d) { return d.stroke || $tree.options.lineStroke})
                                 .attr("d", function(d) {
@@ -689,7 +704,9 @@ module.exports = KBWidget({
         }
 
         var root = this.dataset();
-        root.children.forEach(toggleAll);
+        if (root.children) {
+            root.children.forEach(toggleAll);
+        }
 
 
         this.updateTree(this.dataset());


### PR DESCRIPTION
- swapped behavior of click/double click on node; abstracted click methods to reflect
- allows re-rooting on collapsed nodes or on leaves
- broke apart Tree's tooltip option into nodeOver/nodeOut/textOver/textOut options
- mouseover on node or text will now highlight the tree
- fixed a bug preventing highlighting of tree on subtrees
- minor layout tweak to position of root node
